### PR TITLE
修改SQL为空时导致Inception崩溃的问题。

### DIFF
--- a/include/mysqld_error.h
+++ b/include/mysqld_error.h
@@ -128,7 +128,8 @@
 #define ER_NET_PACKETS_OUT_OF_ORDER         2625
 #define ER_NOT_SUPPORTED_ITEM_TYPE          2626
 #define ER_INVALID_IDENT                    2627
-#define ER_ERROR_LAST                       2628
+#define ER_INCEPTION_EMPTY_QUERY            2628
+#define ER_ERROR_LAST                       2629
 
 #define ER_WARNING 1000
 #define ER_NISAMCHK 1001

--- a/sql/derror.cc
+++ b/sql/derror.cc
@@ -196,6 +196,7 @@ bool init_errmessage(void)
   SERVER_SETMSG(ER_NET_PACKETS_OUT_OF_ORDER, "Got packets out of order");
   SERVER_SETMSG(ER_NOT_SUPPORTED_ITEM_TYPE, "Not supported expression type \'%s\'.");
   SERVER_SETMSG(ER_INVALID_IDENT, "Identifier \'%s\' is invalid, valid options: [a-z|A-Z|0-9|_].");
+  SERVER_SETMSG(ER_INCEPTION_EMPTY_QUERY, "Inception error, Query was empty.");
 
 	/* Register messages for use with my_error(). */
 	if (my_error_register(get_server_errmsgs, ER_ERROR_FIRST, ER_ERROR_LAST))

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1956,6 +1956,7 @@ int mysql_get_err_level_by_errno(THD *   thd)
     case ER_COLLATION_CHARSET_MISMATCH:
     case ER_VIEW_SELECT_CLAUSE:
     case ER_NOT_SUPPORTED_ITEM_TYPE:
+    case ER_INCEPTION_EMPTY_QUERY:
         return INCEPTION_PARSE;
 
     default:

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -1970,7 +1970,7 @@ query:
             if (!thd->bootstrap &&
               (!(thd->lex->select_lex.options & OPTION_FOUND_COMMENT)))
             {
-              my_message(ER_EMPTY_QUERY, ER(ER_EMPTY_QUERY), MYF(0));
+              my_message(ER_INCEPTION_EMPTY_QUERY, ER(ER_INCEPTION_EMPTY_QUERY), MYF(0));
               MYSQL_YYABORT;
             }
             thd->lex->sql_command= SQLCOM_EMPTY_QUERY;


### PR DESCRIPTION
如果向Inception提交一个空的SQL（没有选项，也没有inception_magic_start、inception_magic_end这样的标记），Inception会发生崩溃的问题。
此次提交即是修改SQL为空时导致Inception崩溃的问题。