### PR TITLE
修改表名字中有空格导致的段错误

### DIFF
--- a/include/mysqld_error.h
+++ b/include/mysqld_error.h
@@ -129,7 +129,8 @@
 #define ER_NOT_SUPPORTED_ITEM_TYPE          2626
 #define ER_INVALID_IDENT                    2627
 #define ER_INCEPTION_EMPTY_QUERY            2628
-#define ER_ERROR_LAST                       2629
+#define ER_REMOVED_SPACES                   2629
+#define ER_ERROR_LAST                       2630
 
 #define ER_WARNING 1000
 #define ER_NISAMCHK 1001
@@ -583,7 +584,7 @@
 #define ER_NON_GROUPING_FIELD_USED 1463
 #define ER_TABLE_CANT_HANDLE_SPKEYS 1464
 #define ER_NO_TRIGGERS_ON_SYSTEM_SCHEMA 1465
-#define ER_REMOVED_SPACES 1466
+//#define ER_REMOVED_SPACES 1466
 #define ER_AUTOINC_READ_FAILED 1467
 // #define ER_USERNAME 1468
 // #define ER_HOSTNAME 1469

--- a/sql/derror.cc
+++ b/sql/derror.cc
@@ -197,6 +197,8 @@ bool init_errmessage(void)
   SERVER_SETMSG(ER_NOT_SUPPORTED_ITEM_TYPE, "Not supported expression type \'%s\'.");
   SERVER_SETMSG(ER_INVALID_IDENT, "Identifier \'%s\' is invalid, valid options: [a-z|A-Z|0-9|_].");
   SERVER_SETMSG(ER_INCEPTION_EMPTY_QUERY, "Inception error, Query was empty.");
+  SERVER_SETMSG(ER_REMOVED_SPACES, "Leading spaces are removed from name \'%s\'");
+  SERVER_SETMSG(ER_ERROR_LAST, "TheLastError,ByeBye");
 
 	/* Register messages for use with my_error(). */
 	if (my_error_register(get_server_errmsgs, ER_ERROR_FIRST, ER_ERROR_LAST))


### PR DESCRIPTION
如果列名中有空格，例如使用 ``` table_name ```引起，那么就会报段错误，原因是server_errmsgs数组中没有存对应错误码的提示信息。